### PR TITLE
fixed: disable electric-indent-local-mode

### DIFF
--- a/hamlet-mode.el
+++ b/hamlet-mode.el
@@ -170,7 +170,8 @@ no previous nonblank line, the only valid indentation is 0."
   (set (make-local-variable 'font-lock-defaults)
        '(hamlet/font-lock-keywords))
   (set (make-local-variable 'indent-line-function)
-       'hamlet/indent-line))
+       'hamlet/indent-line)
+  (electric-indent-local-mode -1))
 
 
 ;; Associate ourselves with hamlet files.


### PR DESCRIPTION
if electric-indent-local-mode is enabled, then newline action break current line indent.